### PR TITLE
fix: Ensure external project compability (`use client` + global styles)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "sideEffects": [
+    "*.css"
+  ],
   "files": [
     "dist"
   ],

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { LucideIcon } from 'lucide-react';
 
 import type {

--- a/src/components/ui/LinkButton.tsx
+++ b/src/components/ui/LinkButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type {
   ComponentPropsWithRef,
   ElementStatusProps,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   minify: true,
   sourcemap: true,
   treeshake: true,
-  injectStyle: true,
   target: 'es2020',
   tsconfig: 'tsconfig.app.json',
   external: ['react', 'react-dom', 'tailwindcss', 'lucide-react'],


### PR DESCRIPTION
## 🔍 Overview

> This PR fixes compatibility issues when using Framix components in external projects. <br />
Previously, components failed to render without manually adding `'use client'`, and Tailwind-based styles were missing due to improper bundling configuration. <br />
This patch ensures all components are client-compatible and that global styles are included in the build output.

<br />

## 🛠 Changes

- Added `'use client'` directive to all Framix components for universal client rendering.  
- Updated `tsup` configuration:
  - Disabled `injectStyle: true` (incompatible with Tailwind CSS).  
  - Ensured global CSS files are bundled and included in the final build output.  
- Verified that components render correctly in both internal and external Next.js projects.  

<br />

## ❗ Related Issues

- #39

<br />

## 💬 Additional Notes

- This patch will be released as **v0.3.1**.  
- External projects no longer need to manually add `'use client'` to use Framix components.  
- Global CSS is now properly loaded, eliminating `404 Not Found` errors for Tailwind styles.  
