### PR TITLE
feat(form): Implement core Form components

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,27 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import * as clientModule from '../client';
 
 describe('[Root] client.ts', () => {
-  it('should export client-only components', async () => {
-    const clientModule = await import('../client');
-    const exports = Object.keys(clientModule);
-
+  it('should export all modules', async () => {
     expect(clientModule).toBeDefined();
     expect(typeof clientModule).toBe('object');
-
-    expect(exports.length).toBeGreaterThan(0);
-    expect(exports).toContain('Button');
-    expect(exports).toContain('LinkButton');
   });
 
-  it('should re-export Button and LinkButton correctly', async () => {
-    const clientModule = await import('../client');
-    const ButtonModule = await import('../components/ui/Button');
-    const LinkButtonModule = await import('../components/ui/LinkButton');
-
-    expect(clientModule.Button).toBe(ButtonModule.default);
-    expect(typeof clientModule.Button).toBe('function');
-
-    expect(clientModule.LinkButton).toBe(LinkButtonModule.default);
-    expect(typeof clientModule.LinkButton).toBe('function');
+  it('should have correct export structure', async () => {
+    const exports = Object.keys(clientModule);
+    expect(exports.length).toBeGreaterThan(0);
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,15 +1,13 @@
+import * as indexModule from '../index';
+
 describe('[Root] index.ts', () => {
   it('should export all modules', async () => {
-    const indexModule = await import('../index');
-
     expect(indexModule).toBeDefined();
     expect(typeof indexModule).toBe('object');
   });
 
   it('should have correct export structure', async () => {
-    const indexModule = await import('../index');
     const exports = Object.keys(indexModule);
-
     expect(exports.length).toBeGreaterThan(0);
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 'use client';
 
 export { default as Checkbox } from '@components/form/Checkbox';
+export { default as Radio } from '@components/form/Radio';
 
 export { default as Button } from '@components/ui/Button';
 export { default as LinkButton } from '@components/ui/LinkButton';

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,6 @@
 'use client';
 
+export { default as Checkbox } from '@components/form/Checkbox';
+
 export { default as Button } from '@components/ui/Button';
 export { default as LinkButton } from '@components/ui/LinkButton';

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,7 @@
 
 export { default as Checkbox } from '@components/form/Checkbox';
 export { default as Radio } from '@components/form/Radio';
+export { default as RadioGroup } from '@components/form/RadioGroup';
 
 export { default as Button } from '@components/ui/Button';
 export { default as LinkButton } from '@components/ui/LinkButton';

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@
 export { default as Checkbox } from '@components/form/Checkbox';
 export { default as Radio } from '@components/form/Radio';
 export { default as RadioGroup } from '@components/form/RadioGroup';
+export * from '@components/form/Select';
 
 export { default as Button } from '@components/ui/Button';
 export { default as LinkButton } from '@components/ui/LinkButton';

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,7 @@ export { default as Checkbox } from '@components/form/Checkbox';
 export { default as Radio } from '@components/form/Radio';
 export { default as RadioGroup } from '@components/form/RadioGroup';
 export * from '@components/form/Select';
+export { default as Switch } from '@components/form/Switch';
 
 export { default as Button } from '@components/ui/Button';
 export { default as LinkButton } from '@components/ui/LinkButton';

--- a/src/components/form/Checkbox.stories.tsx
+++ b/src/components/form/Checkbox.stories.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Box, Flex } from '@layouts';
+
+import Checkbox from './Checkbox';
+
+const meta = {
+  title: 'Components/Form/Checkbox',
+  tags: ['autodocs'],
+  component: Checkbox,
+  args: {
+    testId: 'checkbox',
+    label: 'Default checkbox',
+    name: 'checkbox',
+    isDisabled: false,
+  },
+  render: args => (
+    <Flex justifyContent="center" alignItems="center" className="w-screen">
+      <Checkbox {...args} />
+    </Flex>
+  ),
+} satisfies Meta<typeof Checkbox>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+type Checkboxes = Record<string, boolean>;
+
+export const Default: Story = {};
+
+export const Controlled: Story = {
+  args: {
+    isChecked: true,
+    value: 'Controlled checkbox',
+    name: 'controlled-checkbox',
+  },
+  render: args => {
+    const [isChecked, setIsChecked] = useState(args.isChecked ?? false);
+    const [onChangeResult, setOnChangeResult] = useState(true);
+
+    useEffect(() => {
+      setIsChecked(args.isChecked ?? false);
+    }, [args.isChecked]);
+
+    useEffect(() => {
+      setOnChangeResult(isChecked);
+    }, [isChecked]);
+
+    return (
+      <Flex alignItems="center" className="w-75">
+        <Checkbox
+          {...args}
+          label={`Controlled checkbox (isChecked: ${String(onChangeResult)})`}
+          isChecked={isChecked}
+          onChange={useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+            e => {
+              setIsChecked(prev => !prev);
+              setOnChangeResult(e.target.checked);
+            },
+            [],
+          )}
+        />
+      </Flex>
+    );
+  },
+};
+
+export const Uncontrolled: Story = {
+  args: {
+    defaultChecked: true,
+    label: 'Uncontrolled checkbox',
+    value: 'Uncontrolled checkbox',
+    name: 'uncontrolled-checkbox',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    isDisabled: true,
+  },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    isIndeterminate: true,
+    label: 'Parent checkbox',
+    value: 'Parent checkbox',
+    name: 'parent-checkbox',
+  },
+  render: args => {
+    const childrenCheckboxes = Array.from({ length: 3 }, (_, i) => ({
+      id: `child-checkbox-${i + 1}`,
+      label: `Child checkbox ${i + 1}`,
+    }));
+    const getInitialCheckedItems = (): Checkboxes =>
+      Object.fromEntries(
+        childrenCheckboxes.map(childCheckbox => [childCheckbox.id, false]),
+      );
+
+    const [childCheckboxes, setChildCheckboxes] = useState<Checkboxes>(
+      getInitialCheckedItems(),
+    );
+
+    const isChildChecked = (id: string): boolean => childCheckboxes[id];
+    const getAllChildren = (): string[] => Object.keys(childCheckboxes);
+    const getCheckedItemsCount = (): number =>
+      getAllChildren().filter(isChildChecked).length;
+
+    const isParentChecked = (): boolean => getCheckedItemsCount() > 0;
+
+    const isIndeterminate = (): boolean => {
+      const checkedCount = getCheckedItemsCount();
+      const notAllChecked =
+        checkedCount > 0 && checkedCount < getAllChildren().length;
+
+      return notAllChecked;
+    };
+
+    const handleParentCheckboxChange: React.ChangeEventHandler<
+      HTMLInputElement
+    > = () => {
+      const newChildCheckboxes: Checkboxes = {};
+      getAllChildren().forEach(id => {
+        const newState = !isParentChecked();
+        newChildCheckboxes[id] = newState;
+      });
+
+      setChildCheckboxes(newChildCheckboxes);
+    };
+
+    const handleChildCheckboxChange: React.ChangeEventHandler<
+      HTMLInputElement
+    > = e => {
+      const { value } = e.target;
+      setChildCheckboxes(prev => ({
+        ...prev,
+        [value]: !isChildChecked(value),
+      }));
+    };
+
+    return (
+      <Box>
+        <Checkbox
+          {...args}
+          isChecked={isParentChecked()}
+          isIndeterminate={isIndeterminate()}
+          onChange={handleParentCheckboxChange}
+        />
+        <Box className="ps-7">
+          {childrenCheckboxes.map(({ id, label }) => (
+            <Checkbox
+              key={id}
+              isChecked={isChildChecked(id)}
+              onChange={handleChildCheckboxChange}
+              label={label}
+              value={id}
+              testId={id}
+            />
+          ))}
+        </Box>
+      </Box>
+    );
+  },
+};

--- a/src/components/form/Checkbox.test.tsx
+++ b/src/components/form/Checkbox.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Checkbox from './Checkbox';
+
+describe('[Form] Checkbox', () => {
+  describe('rendering', () => {
+    it('renders input type=checkbox with defaults', () => {
+      render(<Checkbox />);
+
+      const wrapper = screen.getByTestId('checkbox-wrapper');
+      const input = screen.getByTestId('checkbox') as HTMLInputElement;
+      const svg = wrapper.querySelector('svg');
+
+      expect(wrapper).toBeInTheDocument();
+
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('type', 'checkbox');
+      expect(input).not.toBeDisabled();
+      expect(input.checked).toBe(false);
+
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('renders label text when provided', () => {
+      render(<Checkbox label="Accept terms" />);
+      const wrapper = screen.getByTestId('checkbox-wrapper');
+
+      expect(wrapper).toHaveTextContent('Accept terms');
+    });
+  });
+
+  describe('controlled vs uncontrolled', () => {
+    it('controlled: respects isChecked and does not toggle without prop change', async () => {
+      const onChange = vi.fn();
+      render(<Checkbox isChecked label="c" onChange={onChange} />);
+      const input = screen.getByTestId('checkbox') as HTMLInputElement;
+
+      expect(input.checked).toBe(true);
+
+      await userEvent.click(input);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(input.checked).toBe(true);
+    });
+
+    it('uncontrolled: uses defaultChecked and toggles on click', async () => {
+      const onChange = vi.fn();
+      render(<Checkbox defaultChecked label="u" onChange={onChange} />);
+      const input = screen.getByTestId('checkbox') as HTMLInputElement;
+
+      expect(input.checked).toBe(true);
+
+      await userEvent.click(input);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(input.checked).toBe(false);
+    });
+  });
+
+  describe('states', () => {
+    it('disabled: prevents interaction', async () => {
+      const onChange = vi.fn();
+      render(<Checkbox isDisabled onChange={onChange} />);
+      const wrapper = screen.getByTestId('checkbox-wrapper');
+      const input = screen.getByTestId('checkbox');
+
+      expect(input).toBeDisabled();
+      expect(wrapper.className).toEqual(expect.stringContaining('disabled'));
+
+      await userEvent.click(wrapper);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('indeterminate: renders minus path; transition class persists; visibility toggles by value', () => {
+      const { rerender } = render(<Checkbox isIndeterminate />);
+      const wrapper = screen.getByTestId('checkbox-wrapper');
+      const svg = wrapper.querySelector('svg')!;
+      const minus = wrapper.querySelector('path:last-child');
+
+      expect(svg).toHaveClass('*:not-first:transition-opacity');
+
+      expect(minus).toBeInTheDocument();
+      expect(minus).not.toHaveClass('opacity-0');
+
+      rerender(<Checkbox isIndeterminate={false} />);
+
+      expect(minus).toHaveClass('opacity-0');
+    });
+  });
+
+  describe('interactions', () => {
+    it('label click toggles checkbox in uncontrolled mode', async () => {
+      render(<Checkbox defaultChecked={false} label="Toggle" />);
+      const wrapper = screen.getByTestId('checkbox-wrapper');
+      const input = screen.getByTestId('checkbox') as HTMLInputElement;
+
+      expect(input.checked).toBe(false);
+
+      await userEvent.click(wrapper);
+      expect(input.checked).toBe(true);
+    });
+  });
+
+  describe('prop forwarding', () => {
+    it('merges className into input and forwards data attributes', () => {
+      render(
+        <Checkbox className="border p-1" data-analytics="cb" testId="cb" />,
+      );
+      const input = screen.getByTestId('cb');
+
+      expect(input).toHaveClass('border', 'p-1');
+      expect(input).toHaveAttribute('data-analytics', 'cb');
+    });
+  });
+});

--- a/src/components/form/Checkbox.tsx
+++ b/src/components/form/Checkbox.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { useEffect, useState } from 'react';
 
 import { SquareCheck } from 'lucide-react';
@@ -13,6 +11,8 @@ import type {
 import { cn } from '@utils';
 
 import { Grid } from '@layouts';
+
+import { Text } from '@components/ui';
 
 type CheckboxProps = StrictOmit<
   ComponentPropsWithRef<'input'>,
@@ -48,9 +48,7 @@ const Checkbox = ({
       testId={`${testId}-wrapper`}
       templateColumns={['min-content', 'auto']}
       placeItems="center"
-      gap={{
-        column: 1,
-      }}
+      gap={{ column: 1 }}
       className={cn(
         'cursor-pointer auto-cols-[1fr] auto-rows-min',
 
@@ -94,9 +92,7 @@ const Checkbox = ({
         )}
       </SquareCheck>
       {label.length > 0 && (
-        <span className="text-body2 col-[2/3] row-[1/2] my-auto w-full">
-          {label}
-        </span>
+        <Text className="col-[2/3] row-[1/2] my-auto w-full">{label}</Text>
       )}
     </Grid>
   );

--- a/src/components/form/Checkbox.tsx
+++ b/src/components/form/Checkbox.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { SquareCheck } from 'lucide-react';
+
+import type {
+  CheckableStatusProps,
+  ComponentPropsWithRef,
+  StrictOmit,
+} from '@types';
+
+import { cn } from '@utils';
+
+import { Grid } from '@layouts';
+
+type CheckboxProps = StrictOmit<
+  ComponentPropsWithRef<'input'>,
+  'children' | 'type' | 'size' | 'checked'
+> &
+  StrictOmit<CheckableStatusProps, 'isLoading'> & {
+    isIndeterminate?: boolean;
+  };
+
+const Checkbox = ({
+  testId = 'checkbox',
+  label = '',
+  isDisabled = false,
+  isChecked: checked,
+  isIndeterminate,
+  onChange,
+  defaultChecked = false,
+  ...props
+}: CheckboxProps) => {
+  const isControlled = typeof checked === 'boolean';
+
+  const [isChecked, setIsChecked] = useState<boolean>(
+    isControlled ? checked : defaultChecked,
+  );
+
+  useEffect(() => {
+    if (isControlled) setIsChecked(checked);
+  }, [isControlled, checked]);
+
+  return (
+    <Grid
+      as="label"
+      testId={`${testId}-wrapper`}
+      templateColumns={['min-content', 'auto']}
+      placeItems="center"
+      gap={{
+        column: 1,
+      }}
+      className={cn(
+        'cursor-pointer auto-cols-[1fr] auto-rows-min',
+
+        // states
+        isDisabled && 'disabled',
+      )}
+    >
+      <input
+        {...props}
+        tabIndex={0}
+        type="checkbox"
+        data-testid={testId}
+        checked={isChecked}
+        disabled={isDisabled}
+        onChange={e => {
+          if (!isControlled) setIsChecked(e.target.checked);
+          onChange?.(e);
+        }}
+        className={cn(
+          props.className,
+          'col-[1/2] row-[1/2] size-6 cursor-pointer appearance-none opacity-0',
+        )}
+      />
+      <SquareCheck
+        size={16}
+        aria-hidden={true}
+        focusable={false}
+        className={cn(
+          '*:not-first:stroke-foreground-dark dark:*:not-first:stroke-foreground-light col-[1/2] row-[1/2] m-auto flex items-center justify-center transition-colors *:not-first:-translate-1/4 *:not-first:scale-150 *:not-first:transition-opacity',
+
+          // states
+          isDisabled && 'disabled',
+          isChecked &&
+            'fill-primary-light dark:fill-primary-dark *:first:stroke-primary-light dark:*:first:stroke-primary-dark',
+          ((isChecked && isIndeterminate) || !isChecked) &&
+            '*:not-last:[path]:pointer-events-none *:not-last:[path]:opacity-0',
+        )}
+      >
+        {typeof isIndeterminate !== 'undefined' && (
+          <path d="M8 12h8" className={cn(!isIndeterminate && 'opacity-0')} />
+        )}
+      </SquareCheck>
+      {label.length > 0 && (
+        <span className="text-body2 col-[2/3] row-[1/2] my-auto w-full">
+          {label}
+        </span>
+      )}
+    </Grid>
+  );
+};
+
+export default Checkbox;

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+
+import type {
+  CheckableStatusProps,
+  ComponentPropsWithRef,
+  StrictOmit,
+} from '@types';
+
+import { cn } from '@utils';
+
+import { Grid } from '@layouts';
+
+import { Text } from '@components/ui';
+
+type RadioProps = StrictOmit<
+  ComponentPropsWithRef<'input'>,
+  'children' | 'type' | 'size' | 'checked'
+> &
+  StrictOmit<CheckableStatusProps, 'isLoading'>;
+
+const Radio = ({
+  testId = 'radio',
+  label = '',
+  isDisabled = false,
+  isChecked: checked,
+  onChange,
+  defaultChecked = false,
+  ...props
+}: RadioProps) => {
+  const isControlled = typeof checked === 'boolean';
+
+  const [isChecked, setIsChecked] = useState<boolean>(
+    isControlled ? checked : defaultChecked,
+  );
+
+  useEffect(() => {
+    if (isControlled) setIsChecked(checked);
+  }, [isControlled, checked]);
+
+  return (
+    <Grid
+      as="label"
+      testId={`${testId}-wrapper`}
+      templateColumns={['min-content', 'auto']}
+      placeItems="center"
+      gap={{ column: 1 }}
+      className={cn(
+        'group cursor-pointer auto-cols-[1fr] auto-rows-min',
+
+        // status
+        isDisabled && 'disabled',
+      )}
+    >
+      <input
+        {...props}
+        tabIndex={0}
+        type="radio"
+        data-testid={testId}
+        checked={isChecked}
+        disabled={isDisabled}
+        onChange={e => {
+          if (!isControlled) setIsChecked(e.target.checked);
+          onChange?.(e);
+        }}
+        className={cn(
+          props.className,
+          'col-[1/2] row-[1/2] size-6 cursor-pointer appearance-none opacity-0',
+        )}
+      />
+      <span className="col-[1/2] row-[1/2]">
+        <svg
+          aria-hidden={true}
+          focusable={false}
+          width={24}
+          height={24}
+          viewBox="0 0 24 24"
+        >
+          <circle
+            cx={12}
+            cy={12}
+            r={8}
+            strokeWidth={1.5}
+            className={cn(
+              'stroke-foreground-light/38 group-hover:stroke-foreground-light dark:stroke-foreground-dark/38 dark:group-hover:stroke-foreground-dark fill-transparent transition-colors',
+
+              isChecked && 'stroke-primary-light dark:stroke-primary-dark',
+            )}
+          />
+          <circle
+            cx={12}
+            cy={12}
+            r={4.5}
+            className={cn(
+              'fill-primary-light dark:fill-primary-dark transition-opacity',
+              !isChecked && 'opacity-0',
+            )}
+          />
+        </svg>
+      </span>
+      {label.length > 0 && (
+        <Text className="col-[2/3] row-[1/2] my-auto w-full">{label}</Text>
+      )}
+    </Grid>
+  );
+};
+
+export default Radio;

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 import type {
   CheckableStatusProps,
   ComponentPropsWithRef,
@@ -12,30 +10,33 @@ import { Grid } from '@layouts';
 
 import { Text } from '@components/ui';
 
+import { useRadioGroup } from './RadioGroup.context';
+
 type RadioProps = StrictOmit<
   ComponentPropsWithRef<'input'>,
-  'children' | 'type' | 'size' | 'checked'
+  | 'children'
+  | 'type'
+  | 'size'
+  | 'checked'
+  | 'defaultChecked'
+  | 'value'
+  | 'onChange'
 > &
-  StrictOmit<CheckableStatusProps, 'isLoading'>;
+  Pick<CheckableStatusProps, 'isDisabled'> & {
+    value?: string;
+  };
 
 const Radio = ({
   testId = 'radio',
-  label = '',
-  isDisabled = false,
-  isChecked: checked,
-  onChange,
-  defaultChecked = false,
+  value = '',
+  label = value,
+  isDisabled: disabled = false,
   ...props
 }: RadioProps) => {
-  const isControlled = typeof checked === 'boolean';
+  const group = useRadioGroup();
 
-  const [isChecked, setIsChecked] = useState<boolean>(
-    isControlled ? checked : defaultChecked,
-  );
-
-  useEffect(() => {
-    if (isControlled) setIsChecked(checked);
-  }, [isControlled, checked]);
+  const isChecked = group.value === value;
+  const isDisabled: boolean = disabled || group.isDisabled;
 
   return (
     <Grid
@@ -56,12 +57,11 @@ const Radio = ({
         tabIndex={0}
         type="radio"
         data-testid={testId}
+        value={value}
+        name={group.name}
         checked={isChecked}
         disabled={isDisabled}
-        onChange={e => {
-          if (!isControlled) setIsChecked(e.target.checked);
-          onChange?.(e);
-        }}
+        onChange={e => group.onChange(e.target.value)}
         className={cn(
           props.className,
           'col-[1/2] row-[1/2] size-6 cursor-pointer appearance-none opacity-0',
@@ -81,9 +81,12 @@ const Radio = ({
             r={8}
             strokeWidth={1.5}
             className={cn(
-              'stroke-foreground-light/38 group-hover:stroke-foreground-light dark:stroke-foreground-dark/38 dark:group-hover:stroke-foreground-dark fill-transparent transition-colors',
+              'stroke-foreground-light/38 dark:stroke-foreground-dark/38 fill-transparent transition-colors',
 
-              isChecked && 'stroke-primary-light dark:stroke-primary-dark',
+              // status
+              isChecked
+                ? 'stroke-primary-light dark:stroke-primary-dark'
+                : 'group-not-disabled:group-hover:stroke-foreground-light dark:group-not-disabled:group-hover:stroke-foreground-dark',
             )}
           />
           <circle

--- a/src/components/form/RadioGroup.context.ts
+++ b/src/components/form/RadioGroup.context.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+
+import type { ElementStatusProps } from '@types';
+
+type RadioGroupContextProps = Required<
+  Pick<ElementStatusProps, 'isDisabled'>
+> & {
+  value: string | undefined;
+  onChange: (value: string) => void;
+  name: string;
+};
+
+const RadioGroupContext = createContext<RadioGroupContextProps | null>(null);
+
+export const RadioGroupProvider = RadioGroupContext.Provider;
+
+export const useRadioGroup = () => {
+  const context = useContext(RadioGroupContext);
+
+  if (!context) throw new Error('Radio must be used within a RadioGroup');
+  return context;
+};

--- a/src/components/form/RadioGroup.stories.tsx
+++ b/src/components/form/RadioGroup.stories.tsx
@@ -50,7 +50,7 @@ export const Controlled: Story = {
     }, [args.value]);
 
     return (
-      <Grid gap={{ row: 4 }} className="w-40 justify-stretch!">
+      <Grid justifyContent="stretch" gap={{ row: 4 }} className="w-40">
         <RadioGroup {...args} value={value} onChange={handleChange}>
           <Radio value="red" label="Red" />
           <Radio value="blue" label="Blue" />

--- a/src/components/form/RadioGroup.stories.tsx
+++ b/src/components/form/RadioGroup.stories.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Grid } from '@layouts';
+
+import { Text } from '@components/ui';
+
+import Radio from './Radio';
+import RadioGroup from './RadioGroup';
+
+const meta = {
+  title: 'Components/Form/RadioGroup',
+  component: RadioGroup,
+  args: {
+    isDisabled: false,
+    value: '',
+    defaultValue: '',
+    name: 'color',
+  },
+} satisfies Meta<typeof RadioGroup>;
+export default meta;
+
+type Story = StoryObj<typeof RadioGroup>;
+
+export const Default: Story = {
+  render: args => {
+    return (
+      <RadioGroup {...args} defaultValue="red">
+        <Radio value="red" label="Red" />
+        <Radio value="blue" label="Blue" />
+      </RadioGroup>
+    );
+  },
+};
+
+export const Controlled: Story = {
+  args: {
+    value: 'red',
+  },
+  render: args => {
+    const [value, setValue] = useState<string>('red');
+
+    const handleChange = (value: string) => {
+      setValue(value);
+    };
+
+    useEffect(() => {
+      setValue(args.value ?? 'red');
+    }, [args.value]);
+
+    return (
+      <Grid gap={{ row: 4 }} className="w-40 justify-stretch!">
+        <RadioGroup {...args} value={value} onChange={handleChange}>
+          <Radio value="red" label="Red" />
+          <Radio value="blue" label="Blue" />
+        </RadioGroup>
+        <Text as="p">Selected value: {value}</Text>
+      </Grid>
+    );
+  },
+};
+
+export const AllDisabled: Story = {
+  args: {
+    name: 'color',
+    isDisabled: true,
+  },
+  render: args => {
+    return (
+      <RadioGroup {...args}>
+        <Radio value="red" label="Red" />
+        <Radio value="blue" label="Blue" />
+        <Radio value="yellow" label="Yellow" />
+      </RadioGroup>
+    );
+  },
+};
+
+export const PartiallyDisabled: Story = {
+  args: {
+    name: 'color',
+  },
+  render: args => {
+    return (
+      <RadioGroup {...args}>
+        <Radio value="red" label="Red" />
+        <Radio value="blue" label="Blue" />
+        <Radio value="green" label="Green" isDisabled />
+      </RadioGroup>
+    );
+  },
+};

--- a/src/components/form/RadioGroup.test.tsx
+++ b/src/components/form/RadioGroup.test.tsx
@@ -1,0 +1,167 @@
+import { vi } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Radio from './Radio';
+import RadioGroup from './RadioGroup';
+
+describe('[Form] RadioGroup (comprehensive)', () => {
+  describe('rendering and name propagation', () => {
+    it('renders children and propagates name', () => {
+      render(
+        <RadioGroup name="color">
+          <Radio value="red" label="Red" />
+          <Radio value="blue" label="Blue" />
+        </RadioGroup>,
+      );
+      const inputs = screen.getAllByRole('radio');
+
+      expect(inputs).toHaveLength(2);
+      expect(inputs[0]).toHaveAttribute('name', 'color');
+      expect(inputs[1]).toHaveAttribute('name', 'color');
+    });
+  });
+
+  describe('uncontrolled interactions', () => {
+    it('defaultValue selects initially and toggles on wrapper click', async () => {
+      render(
+        <RadioGroup name="color" defaultValue="red">
+          <Radio value="red" label="Red" />
+          <Radio value="blue" label="Blue" />
+        </RadioGroup>,
+      );
+      const wrappers = screen.getAllByTestId('radio-wrapper');
+      const inputs = screen.getAllByRole('radio') as HTMLInputElement[];
+
+      expect(inputs[0].checked).toBe(true);
+      expect(inputs[1].checked).toBe(false);
+
+      await userEvent.click(wrappers[1]);
+
+      expect(inputs[0].checked).toBe(false);
+      expect(inputs[1].checked).toBe(true);
+    });
+
+    it('Space selects the focused radio', async () => {
+      render(
+        <RadioGroup name="color">
+          <Radio value="red" label="Red" />
+          <Radio value="blue" label="Blue" />
+        </RadioGroup>,
+      );
+      const inputs = screen.getAllByRole('radio') as HTMLInputElement[];
+
+      inputs[1].focus();
+      await userEvent.keyboard('[Space]');
+
+      expect(inputs[0].checked).toBe(false);
+      expect(inputs[1].checked).toBe(true);
+    });
+  });
+
+  describe('controlled flow', () => {
+    it('fires onChange and relies on parent to update value', async () => {
+      const onChange = vi.fn();
+      const { rerender } = render(
+        <RadioGroup name="color" value="red" onChange={onChange}>
+          <Radio value="red" label="Red" />
+          <Radio value="blue" label="Blue" />
+        </RadioGroup>,
+      );
+      const wrappers = screen.getAllByTestId('radio-wrapper');
+      const inputs = screen.getAllByRole('radio') as HTMLInputElement[];
+
+      expect(inputs[0].checked).toBe(true);
+      expect(inputs[1].checked).toBe(false);
+
+      await userEvent.click(wrappers[1]);
+
+      expect(onChange).toHaveBeenCalledWith('blue');
+      expect(inputs[0].checked).toBe(true);
+      expect(inputs[1].checked).toBe(false);
+
+      rerender(
+        <RadioGroup name="color" value="blue" onChange={onChange}>
+          <Radio value="red" label="Red" />
+          <Radio value="blue" label="Blue" />
+        </RadioGroup>,
+      );
+
+      expect(inputs[0].checked).toBe(false);
+      expect(inputs[1].checked).toBe(true);
+    });
+  });
+
+  describe('form submission', () => {
+    it('submits only selected value', async () => {
+      let submitted: Record<string, FormDataEntryValue> | null = null;
+      const handleSubmit = vi.fn((e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        submitted = Object.fromEntries(new FormData(e.currentTarget).entries());
+      });
+
+      render(
+        <form onSubmit={handleSubmit}>
+          <RadioGroup name="color" defaultValue="blue">
+            <Radio value="red" label="Red" />
+            <Radio value="blue" label="Blue" />
+          </RadioGroup>
+          <button type="submit">submit</button>
+        </form>,
+      );
+
+      await userEvent.click(screen.getByText('submit'));
+      expect(submitted).toEqual({ color: 'blue' });
+    });
+  });
+
+  describe('disabled states', () => {
+    it('group disabled disables all children and blocks change', async () => {
+      const onChange = vi.fn();
+      render(
+        <RadioGroup name="color" isDisabled onChange={onChange}>
+          <Radio value="red" label="Red" />
+          <Radio value="blue" label="Blue" />
+          <Radio value="yellow" label="Yellow" />
+        </RadioGroup>,
+      );
+      const wrappers = screen.getAllByTestId('radio-wrapper');
+      const inputs = screen.getAllByRole('radio');
+
+      wrappers.forEach(wrapper => expect(wrapper).toHaveClass('disabled'));
+      inputs.forEach(i => expect(i).toBeDisabled());
+
+      await userEvent.click(wrappers[2]);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('partial disabled child remains inactive while others toggle', async () => {
+      render(
+        <RadioGroup name="color">
+          <Radio value="red" label="Red" />
+          <Radio value="blue" label="Blue" />
+          <Radio value="green" label="Green" isDisabled />
+        </RadioGroup>,
+      );
+      const wrappers = screen.getAllByTestId('radio-wrapper');
+      const inputs = screen.getAllByRole('radio') as HTMLInputElement[];
+
+      expect(inputs[2]).toBeDisabled();
+
+      await userEvent.click(wrappers[2]);
+      expect(inputs[2].checked).toBe(false);
+
+      await userEvent.click(wrappers[0]);
+      expect(inputs[0].checked).toBe(true);
+    });
+  });
+
+  describe('context enforcement', () => {
+    it('throws when Radio is used outside of RadioGroup', () => {
+      expect(() => render(<Radio value="solo" label="Solo" />)).toThrow(
+        'Radio must be used within a RadioGroup',
+      );
+    });
+  });
+});

--- a/src/components/form/RadioGroup.tsx
+++ b/src/components/form/RadioGroup.tsx
@@ -20,15 +20,15 @@ type RadioGroupProps = EssentialProps<true> & {
 const RadioGroup = ({
   children,
   testId = 'radio-group',
-  value = '',
-  defaultValue = value,
+  value,
+  defaultValue = '',
   name = 'radio-group',
   onChange,
   isDisabled = false,
 }: RadioGroupProps) => {
   const [selectedValue, setSelectedValue] = useState<string>(defaultValue);
 
-  const isControlled = value.length > 0;
+  const isControlled = typeof value !== 'undefined';
   const currentValue = isControlled ? value : selectedValue;
 
   const handleChange = (value: string) => {

--- a/src/components/form/RadioGroup.tsx
+++ b/src/components/form/RadioGroup.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import type { ElementStatusProps, EssentialProps } from '@types';
+
+import { Box } from '@layouts';
+
+import Radio from './Radio';
+import { RadioGroupProvider } from './RadioGroup.context';
+
+type OneOrMany<T> = T | readonly T[];
+
+type RadioGroupProps = EssentialProps<true> & {
+  children?: OneOrMany<React.ReactElement<typeof Radio>>;
+  value?: string;
+  defaultValue?: string;
+  name?: string;
+  onChange?: (value: string) => void;
+} & Pick<ElementStatusProps, 'isDisabled'>;
+
+const RadioGroup = ({
+  children,
+  testId = 'radio-group',
+  value = '',
+  defaultValue = value,
+  name = 'radio-group',
+  onChange,
+  isDisabled = false,
+}: RadioGroupProps) => {
+  const [selectedValue, setSelectedValue] = useState<string>(defaultValue);
+
+  const isControlled = value.length > 0;
+  const currentValue = isControlled ? value : selectedValue;
+
+  const handleChange = (value: string) => {
+    if (!isControlled) setSelectedValue(value);
+    onChange?.(value);
+  };
+
+  return (
+    <RadioGroupProvider
+      value={{
+        value: currentValue,
+        onChange: handleChange,
+        name,
+        isDisabled,
+      }}
+    >
+      <Box testId={testId} className="w-full space-y-2">
+        {children}
+      </Box>
+    </RadioGroupProvider>
+  );
+};
+
+export default RadioGroup;

--- a/src/components/form/Select/Select.context.ts
+++ b/src/components/form/Select/Select.context.ts
@@ -1,0 +1,29 @@
+import { createContext, useContext } from 'react';
+
+import type { ElementStatusProps } from '@types';
+
+export type SelectIds = {
+  base: string;
+  trigger: string;
+  content: string;
+};
+
+type SelectContextValue = Required<Pick<ElementStatusProps, 'isDisabled'>> & {
+  value: string;
+  ids: SelectIds;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<SelectContextValue['open']>>;
+  getContent: (value: string) => string;
+  onChange: (value: string) => void;
+};
+
+const SelectContext = createContext<SelectContextValue | null>(null);
+
+export const SelectProvider = SelectContext.Provider;
+
+export const useSelect = (caller: string) => {
+  const context = useContext(SelectContext);
+
+  if (!context) throw new Error(`${caller} must be used within a <Select>`);
+  return context;
+};

--- a/src/components/form/Select/Select.stories.tsx
+++ b/src/components/form/Select/Select.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import Select from './Select';
+import SelectContent from './SelectContent';
+import SelectItem from './SelectItem';
+import SelectTrigger from './SelectTrigger';
+
+const meta = {
+  title: 'Components/Form/Select',
+  component: Select,
+  args: {},
+} satisfies Meta<typeof Select>;
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+const options = [
+  { value: 'apple', content: 'Apple' },
+  { value: 'banana', content: 'Banana' },
+  { value: 'peach', content: 'Peach' },
+] satisfies { value: string; content: string }[];
+
+export const Default: Story = {
+  render: args => {
+    return (
+      <Select
+        {...args}
+        getContent={value =>
+          options.find(option => option.value === value)?.content ?? ''
+        }
+      >
+        <SelectTrigger placeholder="Fruits" />
+        <SelectContent>
+          {options.map(({ value, content }) => (
+            <SelectItem key={value} value={value}>
+              {content}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  },
+};

--- a/src/components/form/Select/Select.test.tsx
+++ b/src/components/form/Select/Select.test.tsx
@@ -1,0 +1,286 @@
+import { vi } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Select from './Select';
+import SelectContent from './SelectContent';
+import SelectItem from './SelectItem';
+import SelectTrigger from './SelectTrigger';
+
+const options = [
+  { value: 'apple', content: 'Apple' },
+  { value: 'banana', content: 'Banana' },
+  { value: 'peach', content: 'Peach' },
+];
+
+const getContent = (value: string) =>
+  options.find(option => option.value === value)?.content ?? '';
+
+const renderBase = (
+  override: Partial<React.ComponentProps<typeof Select>> = {},
+) =>
+  render(
+    <Select
+      getContent={value => options.find(o => o.value === value)?.content ?? ''}
+      {...override}
+    >
+      <SelectTrigger placeholder="Fruits" />
+      <SelectContent>
+        {options.map(o => (
+          <SelectItem key={o.value} value={o.value}>
+            {o.content}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>,
+  );
+
+describe('[Form] Select (current implementation)', () => {
+  describe('rendering & structure', () => {
+    it('renders trigger (combobox) with aria linkage to listbox and placeholder label', () => {
+      renderBase();
+      const label = screen.getByTestId('select-trigger-label');
+      const trigger = screen.getByTestId('select-trigger') as HTMLInputElement;
+      const controls = trigger.getAttribute('aria-controls');
+      const content = screen.getByTestId('select-content');
+
+      expect(label).toBeInTheDocument();
+      expect(label).toHaveTextContent('Fruits');
+      expect(trigger.value).toBe('');
+
+      expect(trigger).toBeInTheDocument();
+      expect(trigger).toHaveAttribute('role', 'combobox');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(controls).toBeTruthy();
+
+      expect(content).toBeInTheDocument();
+      expect(content.id).toBe(controls);
+      expect(content).toHaveAttribute('role', 'listbox');
+    });
+
+    it('uses built-in defaultGetContent when getContent prop is omitted', async () => {
+      render(
+        <Select defaultValue="apple">
+          <SelectTrigger placeholder="Fruits" />
+          <SelectContent>
+            {options.map(({ value, content }) => (
+              <SelectItem key={value} value={value}>
+                {content}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>,
+      );
+      const trigger = screen.getByTestId('select-trigger') as HTMLInputElement;
+
+      expect(trigger.value).toBe('apple');
+
+      await userEvent.click(trigger);
+      await userEvent.click(screen.getByRole('option', { name: 'Banana' }));
+
+      expect(trigger.value).toBe('banana');
+    });
+  });
+
+  describe('open / close interactions', () => {
+    it('opens on trigger click and closes after selecting an option', async () => {
+      renderBase();
+      const trigger = screen.getByTestId('select-trigger') as HTMLInputElement;
+      const content = screen.getByTestId('select-content');
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(content.className).toContain('opacity-0');
+
+      await userEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      const option = screen.getByText('Banana');
+      await userEvent.click(option);
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(trigger.value).toBe('Banana');
+    });
+
+    it('closes when clicking outside while open', async () => {
+      render(
+        <>
+          <button data-testid="outside">outside</button>
+          <Select getContent={getContent}>
+            <SelectTrigger placeholder="Fruits" />
+            <SelectContent>
+              {options.map(({ value, content }) => (
+                <SelectItem key={value} value={value}>
+                  {content}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </>,
+      );
+      const trigger = screen.getByTestId('select-trigger');
+      const outside = screen.getByTestId('outside');
+
+      await userEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      await userEvent.click(outside);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  describe('uncontrolled value flow', () => {
+    it('defaultValue sets initial displayed content via getContent', () => {
+      renderBase({ defaultValue: 'banana' });
+      const trigger = screen.getByTestId('select-trigger') as HTMLInputElement;
+
+      expect(trigger.value).toBe('Banana');
+    });
+
+    it('selecting an option updates displayed value (internal state)', async () => {
+      renderBase({ defaultValue: 'apple' });
+      const trigger = screen.getByTestId('select-trigger') as HTMLInputElement;
+
+      expect(trigger.value).toBe('Apple');
+
+      await userEvent.click(trigger);
+      await userEvent.click(screen.getByText('Peach'));
+
+      expect(trigger.value).toBe('Peach');
+    });
+  });
+
+  describe('controlled value flow', () => {
+    it('invokes onChange and relies on parent to update value', async () => {
+      const onChange = vi.fn();
+      const { rerender } = renderBase({ value: 'apple', onChange });
+      const trigger = screen.getByTestId('select-trigger') as HTMLInputElement;
+
+      expect(trigger.value).toBe('Apple');
+
+      await userEvent.click(trigger);
+      await userEvent.click(screen.getByText('Banana'));
+
+      expect(onChange).toHaveBeenCalledWith('banana');
+      expect(trigger.value).toBe('Apple');
+
+      rerender(
+        <Select getContent={getContent} value="banana" onChange={onChange}>
+          <SelectTrigger placeholder="Fruits" />
+          <SelectContent>
+            {options.map(({ value, content }) => (
+              <SelectItem key={value} value={value}>
+                {content}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>,
+      );
+
+      expect(trigger.value).toBe('Banana');
+    });
+  });
+
+  describe('context enforcement', () => {
+    it('throws if SelectTrigger is rendered outside of Select', () => {
+      expect(() => render(<SelectTrigger placeholder="Alone" />)).toThrow(
+        'SelectTrigger must be used within a <Select>',
+      );
+    });
+  });
+
+  describe('defensive branches', () => {
+    it('early returns without crashing if unmounted before effect commit', () => {
+      const addSpy = vi.spyOn(document, 'addEventListener');
+      const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+      const { unmount } = render(
+        <Select
+          getContent={v => options.find(o => o.value === v)?.content ?? ''}
+        >
+          <SelectTrigger placeholder="Fruits" />
+          <SelectContent>
+            {options.map(({ value, content }) => (
+              <SelectItem key={value} value={value}>
+                {content}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>,
+      );
+
+      // Immediately unmount to mimic scenario where effect cleanup path runs.
+      unmount();
+
+      // Ensure any click listeners registered were also cleaned (0 or matched add/remove counts)
+      const added = addSpy.mock.calls.filter(c => c[0] === 'click').length;
+      const removed = removeSpy.mock.calls.filter(c => c[0] === 'click').length;
+
+      expect(removed).toBe(added);
+
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    });
+  });
+
+  describe('SelectItem keyboard interactions', () => {
+    it('selects an option with Enter key', async () => {
+      const onChange = vi.fn();
+      renderBase({ onChange });
+      const trigger = screen.getByTestId('select-trigger');
+
+      await userEvent.click(trigger);
+
+      const banana = screen.getByRole('option', { name: 'Banana' });
+      banana.focus();
+      await userEvent.keyboard('{Enter}');
+
+      expect(onChange).toHaveBeenCalledWith('banana');
+    });
+
+    it('selects an option with Space key', async () => {
+      const onChange = vi.fn();
+      renderBase({ onChange });
+      const trigger = screen.getByTestId('select-trigger');
+
+      await userEvent.click(trigger);
+
+      const peach = screen.getByRole('option', { name: 'Peach' });
+      peach.focus();
+      await userEvent.keyboard(' '); // Spacebar
+
+      expect(onChange).toHaveBeenCalledWith('peach');
+    });
+
+    it('does not select a disabled option via keyboard', async () => {
+      const onChange = vi.fn();
+      render(
+        <Select getContent={getContent} onChange={onChange}>
+          <SelectTrigger placeholder="Fruits" />
+          <SelectContent>
+            {[
+              ...options.map(o => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.content}
+                </SelectItem>
+              )),
+              <SelectItem key="disabled-item" value="disabled-item" isDisabled>
+                Disabled Option
+              </SelectItem>,
+            ]}
+          </SelectContent>
+        </Select>,
+      );
+      const trigger = screen.getByTestId('select-trigger');
+
+      await userEvent.click(trigger);
+
+      const disabled = screen.getByRole('option', { name: 'Disabled Option' });
+      disabled.focus();
+      await userEvent.keyboard('{Enter}');
+      await userEvent.keyboard(' ');
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/form/Select/Select.tsx
+++ b/src/components/form/Select/Select.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+
+import type {
+  ComponentPropsWithoutRef,
+  ElementStatusProps,
+  StrictOmit,
+} from '@types';
+
+import { cn } from '@utils';
+
+import { Box } from '@layouts';
+
+import { type SelectIds, SelectProvider } from './Select.context';
+import SelectContent from './SelectContent';
+import SelectTrigger from './SelectTrigger';
+
+type SelectProps = StrictOmit<
+  ComponentPropsWithoutRef<'div', true>,
+  'defaultValue' | 'onChange'
+> &
+  Pick<ElementStatusProps, 'isDisabled'> & {
+    children?:
+      | React.ReactElement<typeof SelectTrigger>
+      | React.ReactElement<typeof SelectContent>[];
+    value?: string;
+    defaultValue?: string;
+    getContent?: (value: string) => string;
+    onChange?: (value: string) => void;
+  };
+
+const defaultGetContent = (value: string) => value;
+
+const Select = ({
+  children,
+  testId = 'select',
+  value,
+  defaultValue = '',
+  getContent = defaultGetContent,
+  onChange,
+  isDisabled = false,
+  ...props
+}: SelectProps) => {
+  const [internalValue, setInternalValue] = useState<string>(defaultValue);
+  const [open, setOpen] = useState<boolean>(false);
+  const selectRef = useRef<HTMLDivElement>(null);
+  const reactId = useId();
+
+  const base = props.id ?? `select-${reactId.replace(/:/g, '')}`;
+  const ids: SelectIds = useMemo(
+    () => ({
+      base,
+      trigger: `${base}-trigger`,
+      content: `${base}-content`,
+    }),
+    [base],
+  );
+
+  const isControlled = typeof value !== 'undefined';
+  const selectedValue = isControlled ? value : internalValue;
+
+  const handleChange = (value: string) => {
+    if (isDisabled) return;
+
+    if (!isControlled) {
+      setInternalValue(value);
+    }
+
+    onChange?.(value);
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (
+        open &&
+        e.target instanceof Node &&
+        selectRef.current &&
+        !selectRef.current.contains(e.target)
+      ) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, [open]);
+
+  return (
+    <SelectProvider
+      value={{
+        isDisabled,
+        value: selectedValue,
+        ids,
+        open,
+        setOpen,
+        getContent,
+        onChange: handleChange,
+      }}
+    >
+      <Box
+        {...props}
+        ref={selectRef}
+        testId={testId}
+        className={cn(
+          props.className,
+          'relative **:[label]:group-has-[input:focus]:pointer-events-none',
+        )}
+      >
+        {children}
+      </Box>
+    </SelectProvider>
+  );
+};
+
+export default Select;

--- a/src/components/form/Select/SelectContent.tsx
+++ b/src/components/form/Select/SelectContent.tsx
@@ -19,8 +19,9 @@ const SelectContent = ({
       id={ids.content}
       label="Select content"
       testId="select-content"
+      justifyContent="stretch"
       className={cn(
-        'bg-background-light shadow-overlay dark:bg-secondary-dark absolute top-full z-10 mt-1 min-w-full justify-stretch! rounded py-2 transition-all',
+        'bg-background-light shadow-overlay dark:bg-secondary-dark absolute top-full z-10 mt-1 min-w-full rounded py-2 transition-all',
         !open && 'pointer-events-none translate-y-1 opacity-0',
       )}
     >

--- a/src/components/form/Select/SelectContent.tsx
+++ b/src/components/form/Select/SelectContent.tsx
@@ -8,7 +8,7 @@ import type SelectItem from './SelectItem';
 const SelectContent = ({
   children,
 }: {
-  children: React.ReactElement<typeof SelectItem>[];
+  children: React.ReactElement<React.ComponentProps<typeof SelectItem>>[];
 }) => {
   const { ids, open } = useSelect('SelectContent');
 

--- a/src/components/form/Select/SelectContent.tsx
+++ b/src/components/form/Select/SelectContent.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@utils';
+
+import { Grid } from '@layouts';
+
+import { useSelect } from './Select.context';
+import type SelectItem from './SelectItem';
+
+const SelectContent = ({
+  children,
+}: {
+  children: React.ReactElement<typeof SelectItem>[];
+}) => {
+  const { ids, open } = useSelect('SelectContent');
+
+  return (
+    <Grid
+      as="ul"
+      role="listbox"
+      id={ids.content}
+      label="Select content"
+      testId="select-content"
+      className={cn(
+        'bg-background-light shadow-overlay dark:bg-secondary-dark absolute top-full z-10 mt-1 min-w-full justify-stretch! rounded py-2 transition-all',
+        !open && 'pointer-events-none translate-y-1 opacity-0',
+      )}
+    >
+      {children}
+    </Grid>
+  );
+};
+
+export default SelectContent;

--- a/src/components/form/Select/SelectItem.tsx
+++ b/src/components/form/Select/SelectItem.tsx
@@ -1,0 +1,64 @@
+import type { ElementStatusProps } from '@types';
+
+import { cn } from '@utils';
+
+import { Text } from '@components/ui';
+
+import { useSelect } from './Select.context';
+
+type SelectItemProps = Pick<ElementStatusProps, 'isDisabled'> &
+  Required<
+    React.PropsWithChildren<{
+      value: string;
+    }>
+  >;
+
+const SelectItem = ({
+  children,
+  value,
+  isDisabled: itemDisabled = false,
+}: SelectItemProps) => {
+  const {
+    isDisabled: selectDisabled,
+    value: selected,
+    onChange,
+  } = useSelect('SelectItem');
+
+  const isDisabled: boolean = selectDisabled || itemDisabled;
+  const isSelected: boolean = selected === value;
+
+  return (
+    <li
+      role="option"
+      tabIndex={0}
+      aria-selected={isSelected}
+      aria-disabled={isDisabled}
+      onClick={() => {
+        if (isDisabled) return;
+        onChange(value);
+      }}
+      onKeyDown={e => {
+        if (isDisabled) return;
+
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onChange(value);
+        }
+      }}
+      className={cn(
+        'size-full cursor-pointer px-3 py-2 transition-colors',
+
+        isSelected
+          ? 'bg-secondary-light-hover dark:bg-secondary-dark-active'
+          : !isDisabled &&
+              'hover:bg-secondary-light dark:hover:bg-secondary-dark-hover',
+      )}
+    >
+      <Text as="p" weight={isSelected ? 'semibold' : 'normal'}>
+        {children}
+      </Text>
+    </li>
+  );
+};
+
+export default SelectItem;

--- a/src/components/form/Select/SelectTrigger.tsx
+++ b/src/components/form/Select/SelectTrigger.tsx
@@ -1,0 +1,52 @@
+import { ChevronDown } from 'lucide-react';
+
+import { cn } from '@utils';
+
+import { IconButton } from '@components/ui';
+
+import TextField from '../TextField';
+import { useSelect } from './Select.context';
+
+const SelectTrigger = ({
+  placeholder = 'Select an option',
+}: {
+  placeholder?: string;
+}) => {
+  const { value, ids, open, setOpen, getContent } = useSelect('SelectTrigger');
+
+  const updateOpenState = () => setOpen(prev => !prev);
+
+  return (
+    <TextField
+      ref={node => {
+        /* istanbul ignore next */
+        if (!node) return;
+
+        if (open) node.focus();
+        else node.blur();
+      }}
+      readOnly
+      role="combobox"
+      aria-readonly={true}
+      aria-expanded={open}
+      aria-controls={ids.content}
+      label={placeholder}
+      testId="select-trigger"
+      id={ids.trigger}
+      value={getContent(value)}
+      onClick={updateOpenState}
+      rightInput={
+        <IconButton
+          tabIndex={-1}
+          icon={ChevronDown}
+          variant="icon"
+          size="sm"
+          className={cn('transition-transform', open && 'rotate-180')}
+          onClick={updateOpenState}
+        />
+      }
+    />
+  );
+};
+
+export default SelectTrigger;

--- a/src/components/form/Select/index.ts
+++ b/src/components/form/Select/index.ts
@@ -1,0 +1,4 @@
+export { default as Select } from './Select';
+export { default as SelectContent } from './SelectContent';
+export { default as SelectItem } from './SelectItem';
+export { default as SelectTrigger } from './SelectTrigger';

--- a/src/components/form/Switch.stories.tsx
+++ b/src/components/form/Switch.stories.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { fn } from 'storybook/test';
+
+import Switch from './Switch';
+
+const meta = {
+  title: 'Components/Form/Switch',
+  component: Switch,
+  args: {
+    isDisabled: false,
+    defaultChecked: false,
+    hasShadow: true,
+  },
+} satisfies Meta<typeof Switch>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Controlled: Story = {
+  args: {
+    isChecked: false,
+  },
+  render: args => {
+    const [isChecked, setIsChecked] = useState<boolean>(
+      args.isChecked ?? false,
+    );
+
+    useEffect(() => {
+      setIsChecked(args.isChecked ?? false);
+    }, [args.isChecked]);
+
+    return <Switch {...args} isChecked={isChecked} onChange={setIsChecked} />;
+  },
+};
+
+export const Uncontrolled: Story = {
+  args: {
+    onChange: fn(),
+  },
+  render: args => <Switch {...args} />,
+};
+
+export const Disabled: Story = {
+  args: {
+    isDisabled: true,
+  },
+};
+
+export const NotHasShadow: Story = {
+  args: {
+    hasShadow: false,
+  },
+};

--- a/src/components/form/Switch.test.tsx
+++ b/src/components/form/Switch.test.tsx
@@ -1,0 +1,117 @@
+import { vi } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Switch from './Switch';
+
+const getSwitchElement = (testId: string = 'switch') =>
+  screen.getByTestId(testId);
+
+describe('[Form] Switch', () => {
+  describe('rendering & structure', () => {
+    it('renders as button role=switch with default unchecked state', () => {
+      render(<Switch />);
+      const switchElement = getSwitchElement();
+
+      expect(switchElement).toBeInTheDocument();
+      expect(switchElement.tagName).toBe('button'.toUpperCase());
+      expect(switchElement).toHaveAttribute('role', 'switch');
+      expect(switchElement).toHaveAttribute('aria-checked', 'false');
+      expect(switchElement).not.toBeDisabled();
+    });
+
+    it('applies provided label as aria-label', () => {
+      render(<Switch label="Dark Mode" />);
+      const switchElement = getSwitchElement();
+
+      expect(switchElement).toHaveAttribute('aria-label', 'Dark Mode');
+    });
+  });
+
+  describe('uncontrolled vs controlled', () => {
+    it('uncontrolled: uses defaultChecked and toggles internal state', async () => {
+      const onChange = vi.fn();
+      render(<Switch defaultChecked label="u" onChange={onChange} />);
+      const switchElement = getSwitchElement();
+
+      expect(switchElement).toHaveAttribute('aria-checked', 'true');
+
+      await userEvent.click(switchElement);
+
+      expect(onChange).toHaveBeenCalledWith(false);
+      expect(switchElement).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('controlled: does not change aria-checked until parent updates', async () => {
+      const onChange = vi.fn();
+      const { rerender } = render(
+        <Switch isChecked={false} label="c" onChange={onChange} />,
+      );
+      const switchElement = getSwitchElement();
+
+      expect(switchElement).toHaveAttribute('aria-checked', 'false');
+
+      await userEvent.click(switchElement);
+
+      expect(onChange).toHaveBeenCalledWith(true);
+      expect(switchElement).toHaveAttribute('aria-checked', 'false');
+
+      rerender(<Switch isChecked={true} label="c" onChange={onChange} />);
+      expect(switchElement).toHaveAttribute('aria-checked', 'true');
+    });
+  });
+
+  describe('states', () => {
+    it('disabled: prevents toggling and onChange', async () => {
+      const onChange = vi.fn();
+      render(<Switch isDisabled defaultChecked onChange={onChange} />);
+      const switchElement = getSwitchElement();
+
+      expect(switchElement).toBeDisabled();
+      expect(switchElement).toHaveAttribute('aria-checked', 'true');
+
+      await userEvent.click(switchElement);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(switchElement).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('hasShadow=false removes inner shadow classes', () => {
+      render(<Switch hasShadow={false} />);
+      const switchElement = getSwitchElement();
+
+      expect(switchElement.className).not.toMatch(/shadow-inner/);
+    });
+  });
+
+  describe('interaction', () => {
+    it('click toggles (uncontrolled)', async () => {
+      render(<Switch defaultChecked={false} />);
+      const switchElement = getSwitchElement();
+
+      expect(switchElement).toHaveAttribute('aria-checked', 'false');
+
+      await userEvent.click(switchElement);
+      expect(switchElement).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('knob applies translation class when checked', () => {
+      render(<Switch defaultChecked />);
+      const switchElement = getSwitchElement();
+      const knob = switchElement.querySelector('svg');
+
+      expect(knob).toHaveClass(/translate-x/);
+    });
+  });
+
+  describe('prop forwarding', () => {
+    it('merges className and data attributes', () => {
+      render(<Switch className="outline" data-test="sw" testId="sw" />);
+      const switchElement = getSwitchElement('sw');
+
+      expect(switchElement.className).toMatch(/outline/);
+      expect(switchElement).toHaveAttribute('data-test', 'sw');
+    });
+  });
+});

--- a/src/components/form/Switch.tsx
+++ b/src/components/form/Switch.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+
+import type {
+  CheckableStatusProps,
+  ComponentPropsWithRef,
+  StrictOmit,
+} from '@types';
+
+import { cn } from '@utils';
+
+import { Flex } from '@layouts';
+
+type SwitchProps = StrictOmit<
+  ComponentPropsWithRef<'button'>,
+  'children' | 'onChange'
+> &
+  StrictOmit<CheckableStatusProps, 'isLoading'> & {
+    defaultChecked?: boolean;
+    hasShadow?: boolean;
+    onChange?: (checked: boolean) => void;
+  };
+
+const Switch = ({
+  testId = 'switch',
+  label = 'Switch',
+  isDisabled = false,
+  isChecked: checked,
+  defaultChecked = false,
+  hasShadow = true,
+  onChange,
+  ...props
+}: SwitchProps) => {
+  const [internalChecked, setInternalChecked] =
+    useState<boolean>(defaultChecked);
+
+  const isControlled = typeof checked !== 'undefined';
+  const isChecked: boolean = isControlled ? checked : internalChecked;
+
+  const handleClick = () => {
+    if (isDisabled) return;
+
+    if (!isControlled) {
+      setInternalChecked(!isChecked);
+    }
+    onChange?.(!isChecked);
+  };
+
+  return (
+    <Flex
+      {...props}
+      as="button"
+      type="button"
+      role="switch"
+      testId={testId}
+      label={label}
+      disabled={isDisabled}
+      aria-checked={isChecked}
+      onClick={handleClick}
+      className={cn(
+        props.className,
+        'relative aspect-[3/1] w-9 rounded-full p-0.5 transition-colors not-disabled:cursor-pointer',
+
+        // status
+        isDisabled && 'disabled',
+
+        // background color
+        isChecked
+          ? 'bg-primary-light hover:not-disabled:bg-primary-light-hover dark:bg-primary-dark dark:hover:not-disabled:bg-primary-dark-hover'
+          : 'bg-secondary-dark-active hover:not-disabled:bg-secondary-dark-hover dark:bg-secondary-light-active dark:hover:not-disabled:bg-secondary-light-hover',
+
+        // shadow
+        hasShadow && [
+          'shadow-inner',
+          isChecked
+            ? 'shadow-primary-light-active!'
+            : 'shadow-background-dark! dark:shadow-secondary-dark!',
+        ],
+      )}
+    >
+      <svg
+        width={14}
+        height={14}
+        className={cn(
+          'relative transition-transform',
+
+          // checked
+          isChecked && 'translate-x-[calc((18/14)*100%)]',
+        )}
+      >
+        <circle
+          cx={7}
+          cy={7}
+          r={7}
+          className="dark:fill-background-dark fill-background-light"
+        />
+      </svg>
+    </Flex>
+  );
+};
+
+export default Switch;

--- a/src/components/form/TextField.stories.tsx
+++ b/src/components/form/TextField.stories.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Eye, EyeOff, Mail } from 'lucide-react';
+
+import { IconButton } from '@components/ui';
+
+import TextField from './TextField';
+
+const meta = {
+  title: 'Components/Form/TextField',
+  tags: ['autodocs'],
+  component: TextField,
+  args: {
+    variant: 'outlined',
+    type: 'text',
+    testId: 'text-field',
+    label: '',
+    id: crypto.randomUUID(),
+    isDisabled: false,
+    isRequired: false,
+    hasError: false,
+    description: '',
+  },
+  argTypes: {
+    type: {
+      control: 'select',
+      options: [
+        'email',
+        'number',
+        'password',
+        'search',
+        'tel',
+        'text',
+        'url',
+      ] satisfies Parameters<typeof TextField>[0]['type'][],
+    },
+  },
+} satisfies Meta<typeof TextField>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: 'Outlined',
+    name: 'outlined-text-field',
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    variant: 'filled',
+    label: 'Filled',
+    name: 'filled-text-field',
+  },
+};
+
+export const Text: Story = {
+  args: {
+    variant: 'text',
+    label: 'Text',
+    name: 'text-field',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    isDisabled: true,
+    label: 'Disabled',
+    name: 'disabled-text-field',
+  },
+};
+
+export const Required: Story = {
+  args: {
+    isRequired: true,
+    label: 'Required',
+    name: 'required-text-field',
+    description: 'This field is required.',
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    label: 'Invalid',
+    hasError: true,
+    name: 'invalid-text-field',
+    defaultValue: 'Invalid value',
+    description: 'There is an error with this field.',
+  },
+};
+
+export const EmailType: Story = {
+  args: {
+    type: 'email',
+    label: 'Email',
+    name: 'email-text-field',
+  },
+  render: args => {
+    return <TextField {...args} leftInput={<Mail />} />;
+  },
+};
+
+export const RightInput: Story = {
+  args: {
+    type: 'password',
+    label: 'Password',
+    name: 'password-text-field',
+  },
+  render: args => {
+    const [isShowing, setIsShowing] = useState<boolean>(false);
+
+    const toggleShowing = () => setIsShowing(prev => !prev);
+
+    return (
+      <TextField
+        {...args}
+        type={isShowing ? 'text' : args.type}
+        rightInput={
+          <IconButton
+            icon={isShowing ? Eye : EyeOff}
+            variant="icon"
+            size="sm"
+            onClick={toggleShowing}
+          />
+        }
+        description={`password: ${isShowing ? 'visible' : 'hidden'}`}
+      />
+    );
+  },
+};

--- a/src/components/form/TextField.stories.tsx
+++ b/src/components/form/TextField.stories.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { Eye, EyeOff, Mail } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
 
 import { IconButton } from '@components/ui';
 
@@ -99,7 +99,7 @@ export const EmailType: Story = {
     name: 'email-text-field',
   },
   render: args => {
-    return <TextField {...args} leftInput={<Mail />} />;
+    return <TextField {...args} />;
   },
 };
 

--- a/src/components/form/TextField.test.tsx
+++ b/src/components/form/TextField.test.tsx
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import TextField from './TextField';
+
+describe('[Form] TextField', () => {
+  const base = (override?: Partial<Parameters<typeof TextField>[0]>) => (
+    <TextField label="Label" id="tf-id" name="tf" {...override} />
+  );
+
+  describe('rendering', () => {
+    it('renders outlined variant with default props', () => {
+      render(base());
+      const wrapper = screen.getByTestId('text-field-wrapper');
+      const input = screen.getByRole('textbox');
+      const label = screen.getByTestId('text-field-label');
+
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper).toHaveClass('rounded border');
+
+      expect(input).toBeInTheDocument();
+      expect(input).not.toBeRequired();
+      expect(input).not.toBeDisabled();
+      expect(input).toHaveAttribute('type', 'text');
+      expect(input).toHaveAttribute('placeholder', ' ');
+      expect(input).toHaveAttribute('aria-disabled', 'false');
+      expect(input).toHaveAttribute('aria-invalid', 'false');
+
+      expect(label).toBeInTheDocument();
+      expect(label).toHaveAttribute('for', 'tf-id');
+    });
+
+    it('does not render label when label prop is empty', () => {
+      render(<TextField id="nolab" name="nolab" label="" />);
+      expect(screen.queryByTestId('text-field-label')).toBeNull();
+    });
+  });
+
+  describe('variants', () => {
+    it('filled variant applies background tokens', () => {
+      render(base({ variant: 'filled', label: 'Filled' }));
+      const wrapper = screen.getByTestId('text-field-wrapper');
+
+      expect(wrapper).toHaveClass('bg-secondary-light dark:bg-secondary-dark');
+    });
+
+    it('text variant uses border-y and transparent top border', () => {
+      render(base({ variant: 'text', label: 'Text' }));
+      const wrapper = screen.getByTestId('text-field-wrapper');
+
+      expect(wrapper).toHaveClass('border-y border-t-transparent!');
+    });
+  });
+
+  describe('states', () => {
+    it('disabled state sets disabled attributes and label pointer-events-none', () => {
+      render(base({ isDisabled: true }));
+      const wrapper = screen.getByTestId('text-field-wrapper');
+      const input = screen.getByRole('textbox');
+      const label = screen.getByTestId('text-field-label');
+
+      expect(wrapper).not.toHaveClass('disabled');
+
+      expect(input).toBeDisabled();
+      expect(input).toHaveAttribute('aria-disabled', 'true');
+
+      expect(label).toHaveClass('group-has-disabled:pointer-events-none');
+    });
+
+    it('error state sets aria-invalid and danger classes', () => {
+      render(base({ hasError: true }));
+      const input = screen.getByRole('textbox');
+      const label = screen.getByTestId('text-field-label');
+      const wrapper = screen.getByTestId('text-field-wrapper');
+
+      expect(wrapper).toHaveClass(
+        'border-danger-light dark:border-danger-dark',
+      );
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      expect(label).toHaveClass('text-danger-light dark:text-danger-dark');
+    });
+  });
+
+  describe('required & description', () => {
+    it('shows asterisk for required field and description text', () => {
+      render(
+        <TextField
+          id="req"
+          name="req"
+          label="Required"
+          isRequired
+          description="This field is required."
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      const label = screen.getByTestId('text-field-label');
+      const desc = screen.getByText('This field is required.');
+
+      expect(input).toBeRequired();
+      expect(label).toHaveTextContent('Required*');
+      expect(desc).toBeInTheDocument();
+    });
+  });
+
+  describe('typing interaction', () => {
+    it('accepts user input (uncontrolled) and retains value', async () => {
+      render(<TextField id="t1" name="t1" label="Type" />);
+      const input = screen.getByRole('textbox') as HTMLInputElement;
+
+      await userEvent.type(input, 'hello');
+      expect(input.value).toBe('hello');
+    });
+
+    it('respects provided type attribute', async () => {
+      render(<TextField id="em" name="em" label="Email" type="email" />);
+      const input = screen.getByRole('textbox');
+
+      expect(input).toHaveAttribute('type', 'email');
+    });
+  });
+
+  describe('accessories', () => {
+    it('renders rightInput when provided', () => {
+      render(base({ rightInput: <span data-testid="ri">RI</span> }));
+      const ri = screen.getByTestId('ri');
+
+      expect(ri).toBeInTheDocument();
+    });
+  });
+
+  describe('prop forwarding', () => {
+    it('forwards className and data attributes to input', () => {
+      render(
+        <TextField
+          id="fw"
+          name="fw"
+          label="FW"
+          className="rounded-xl shadow-inner"
+          data-analytics="tf"
+          testId="tf"
+        />,
+      );
+      const input = screen.getByTestId('tf');
+
+      expect(input).toHaveClass('rounded-xl', 'shadow-inner');
+      expect(input).toHaveAttribute('data-analytics', 'tf');
+    });
+  });
+});

--- a/src/components/form/TextField.tsx
+++ b/src/components/form/TextField.tsx
@@ -1,0 +1,152 @@
+import type {
+  ComponentPropsWithRef,
+  ElementStatusProps,
+  ElementVariant,
+  StrictExtract,
+  StrictOmit,
+} from '@types';
+
+import { cn } from '@utils';
+
+import { Flex } from '@layouts';
+
+type TextFieldType = StrictExtract<
+  React.HTMLInputTypeAttribute,
+  'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url'
+>;
+type TextFieldProps = StrictOmit<
+  ComponentPropsWithRef<'input'>,
+  | 'children'
+  | 'type'
+  | 'size'
+  | 'placeholder'
+  | 'required'
+  | 'defaultChecked'
+  | 'checked'
+> &
+  Pick<ElementStatusProps, 'isDisabled'> & {
+    variant?: ElementVariant;
+    type?: TextFieldType;
+    isRequired?: boolean;
+    hasError?: boolean;
+    description?: string;
+    leftInput?: NonNullable<React.ReactNode>;
+    rightInput?: NonNullable<React.ReactNode>;
+  };
+
+const TextField = ({
+  variant = 'outlined',
+  type = 'text',
+  label = '',
+  testId = 'text-field',
+  isDisabled = false,
+  isRequired = false,
+  hasError = false,
+  description = '',
+  rightInput,
+  ...props
+}: TextFieldProps) => {
+  return (
+    <Flex direction="column" gap={{ row: 1 }} className="has-disabled:disabled">
+      <fieldset className="group relative">
+        {label.length > 0 && (
+          <label
+            data-testid={`${testId}-label`}
+            htmlFor={props.id}
+            className={cn(
+              'peer text-body3 group-has-placeholder-shown:not-group-has-[input:focus]:text-body1 absolute z-1 transition-all not-group-has-disabled:cursor-text group-has-disabled:pointer-events-none group-has-[input:focus]:opacity-100',
+
+              // color
+              hasError
+                ? 'text-danger-light dark:text-danger-dark'
+                : 'group-has-[input:focus]:text-primary-light text-foreground-light/38 dark:text-foreground-dark/38 dark:group-has-[input:focus]:text-primary-dark',
+
+              // position
+              variant === 'outlined' ? 'top-0' : 'top-0.5',
+              variant !== 'text' && 'left-2 px-1',
+              variant === 'outlined'
+                ? '-translate-y-1/2 group-has-placeholder-shown:not-group-has-[input:focus]:translate-y-1/2'
+                : variant === 'filled'
+                  ? 'group-has-placeholder-shown:not-group-has-[input:focus]:translate-y-[calc(50%-0.125rem)]'
+                  : 'group-has-placeholder-shown:not-group-has-[input:focus]:translate-y-[calc((19/24)*100%-0.125rem)]',
+
+              // (outlined) background color
+              variant === 'outlined' &&
+                'bg-background-light dark:bg-background-dark',
+            )}
+          >
+            {label}
+            {isRequired && (
+              <span aria-hidden={true} className="ml-1">
+                *
+              </span>
+            )}
+          </label>
+        )}
+        <Flex
+          testId={`${testId}-wrapper`}
+          alignItems="center"
+          className={cn(
+            'transition-all',
+
+            // border
+            variant !== 'text' ? 'rounded border' : 'border-y',
+
+            // border color
+            variant === 'filled'
+              ? 'border-secondary-light dark:border-secondary-dark'
+              : 'border-foreground-light/38 dark:border-foreground-dark/38',
+            variant === 'text' && 'border-t-transparent!',
+            hasError
+              ? 'border-danger-light dark:border-danger-dark'
+              : 'hover:not-has-[input:focus]:not-disabled:border-foreground-light peer-hover:not-has-[input:focus]:not-disabled:border-foreground-light has-[input:focus]:not-disabled:border-primary-light dark:hover:not-has-[input:focus]:not-disabled:border-foreground-dark dark:peer-hover:not-has-[input:focus]:not-disabled:border-foreground-dark dark:has-[input:focus]:not-disabled:border-primary-dark',
+
+            // background color
+            variant === 'filled'
+              ? 'bg-secondary-light dark:bg-secondary-dark'
+              : 'bg-background-light dark:bg-background-dark',
+          )}
+        >
+          <input
+            {...props}
+            aria-disabled={isDisabled}
+            aria-invalid={hasError}
+            data-testid={testId}
+            type={type}
+            placeholder=" "
+            required={isRequired}
+            disabled={isDisabled}
+            className={cn(
+              props.className,
+              'text-body1 outline-none',
+
+              // padding
+              variant !== 'text' && 'px-3',
+              variant === 'outlined' ? 'py-2.75' : 'pt-4.5 pb-1',
+            )}
+          />
+          {rightInput}
+        </Flex>
+      </fieldset>
+      {description.length > 0 && (
+        <p
+          className={cn(
+            'text-body3',
+
+            // validation
+            hasError
+              ? 'text-danger-light dark:text-danger-dark'
+              : 'text-foreground-light/38 dark:text-foreground-dark/38',
+
+            // spacing
+            variant !== 'text' && 'px-3.25',
+          )}
+        >
+          {description}
+        </p>
+      )}
+    </Flex>
+  );
+};
+
+export default TextField;

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,0 +1,1 @@
+export { default as TextField } from './TextField';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import '@styles/index.css';
 
+export * from '@components/form';
 export * from '@components/ui';
 export * from '@layouts';
 export * from '@utils';

--- a/src/layouts/Grid.tsx
+++ b/src/layouts/Grid.tsx
@@ -34,6 +34,7 @@ type GridProps<T extends React.ElementType> = PolymorphicPropsWithRef<
       | 'space-around'
       | 'space-between'
       | 'space-evenly'
+      | 'stretch'
     >;
     /** Aligns grid along the block (column) axis */
     alignContent?: StrictExtract<
@@ -142,6 +143,7 @@ const Grid = <T extends React.ElementType = 'div'>(
             spaceAround: 'justify-around',
             spaceBetween: 'justify-between',
             spaceEvenly: 'justify-evenly',
+            stretch: 'justify-stretch',
           } satisfies CSSValueToClassMap<typeof justifyContent>
         )[camelCase(justifyContent)],
         (

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -131,6 +131,11 @@ export type ElementStatus = (typeof ELEMENT_STATUS)[number];
 export type ElementStatusProps = Partial<Record<ElementStatus, boolean>>;
 export type ElementVariant = (typeof ELEMENT_VARIANTS)[number];
 
+export type CheckableStatus =
+  | StrictExclude<ElementStatus, 'isSelected'>
+  | 'isChecked';
+export type CheckableStatusProps = Partial<Record<CheckableStatus, boolean>>;
+
 export type MaxWidth = ElementSize | 'xl';
 
 type TestIdProps = {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -128,9 +128,7 @@ export type ElementColor = (typeof ELEMENT_COLORS)[number];
 export type ElementSize = (typeof ELEMENT_SIZES)[number];
 export type ElementSpacing = (typeof ELEMENT_SPACINGS)[number];
 export type ElementStatus = (typeof ELEMENT_STATUS)[number];
-export type ElementStatusProps = {
-  [status in ElementStatus]?: boolean;
-};
+export type ElementStatusProps = Partial<Record<ElementStatus, boolean>>;
 export type ElementVariant = (typeof ELEMENT_VARIANTS)[number];
 
 export type MaxWidth = ElementSize | 'xl';


### PR DESCRIPTION
## 🔍 Overview

> This pull request introduces a core set of **Form components** to Framix’s design system.  
> Added components: `TextField`, `Checkbox`, `Radio` / `RadioGroup`, `Select`, and `Switch`.  
> Improvements also include refined type definitions, accessibility support, Storybook stories, and unit tests.

<br />

## 🛠 Changes

- Added 5 new Form components with **controlled**/**uncontrolled** behavior and accessibility attributes
- Implemented `RadioGroup` using React Context, with `Radio` as a separate reusable component
- Created `Select` with compound components (`Trigger`, `Content`, `Item`) and dropdown support
- Introduced `Switch` as a standalone toggle component
- Updated `src/types/common` with additional form-related types
- Enhanced `Grid` layout to support `stretch` option for `justifyContent`
- Added Storybook stories and test coverage for all new components
- Unified exports from `form/index.ts` for consistent usage

<br />

## ❗ Related Issues

- #46 

<br />

## 💬 Additional Notes (Screenshots, URLs, etc.)

- For `Select`, only single-selection is implemented in this release; multi-select and searchable variants will follow later  
- Ensure consistent controlled/uncontrolled detection logic across form components  
- Verify that stories and tests cover edge cases, including accessibility attributes and disabled states  